### PR TITLE
Add support for arbitrary chat completions endpoints

### DIFF
--- a/examples/chatcompletions.py
+++ b/examples/chatcompletions.py
@@ -1,0 +1,52 @@
+# General chat completions endpoint example (using OpenRouter):
+
+from memoripy import MemoryManager, JSONStorage
+from memoripy.implemented_models import ChatCompletionsModel, OllamaEmbeddingModel
+
+def main():
+    # Set API endpoint and key
+    api_endpoint = "https://openrouter.ai/api/v1"
+    # Replace 'your-api-key' with your actual API key for the chat completions service you use
+    api_key = "your-api-key"
+    if not api_key or api_key == "your-api-key":
+        raise ValueError("Please set your API key.")
+
+    # Define chat and embedding models
+    chat_model_name = "nousresearch/hermes-3-llama-3.1-405b:free" # Specific chat model name
+    embedding_model_name = "mxbai-embed-large"  # Specific embedding model name
+
+    # Choose your storage option
+    storage_option = JSONStorage("interaction_history.json")
+    # Or use in-memory storage:
+    # from memoripy import InMemoryStorage
+    # storage_option = InMemoryStorage()
+
+    # Initialize the MemoryManager with the selected models and storage
+    memory_manager = MemoryManager(ChatCompletionsModel(api_endpoint, api_key, chat_model_name), OllamaEmbeddingModel(embedding_model_name), storage=storage_option)
+
+    # New user prompt
+    new_prompt = "My name is Khazar"
+
+    # Load the last 5 interactions from history (for context)
+    short_term, _ = memory_manager.load_history()
+    last_interactions = short_term[-5:] if len(short_term) >= 5 else short_term
+
+    # Retrieve relevant past interactions, excluding the last 5
+    relevant_interactions = memory_manager.retrieve_relevant_interactions(new_prompt, exclude_last_n=5)
+
+    # Generate a response using the last interactions and retrieved interactions
+    response = memory_manager.generate_response(new_prompt, last_interactions, relevant_interactions)
+
+    # Display the response
+    print(f"Generated response:\n{response}")
+
+    # Extract concepts for the new interaction
+    combined_text = f"{new_prompt} {response}"
+    concepts = memory_manager.extract_concepts(combined_text)
+
+    # Store this new interaction along with its embedding and concepts
+    new_embedding = memory_manager.get_embedding(combined_text)
+    memory_manager.add_interaction(new_prompt, response, new_embedding, concepts)
+
+if __name__ == "__main__":
+    main()

--- a/examples/openai_example.py
+++ b/examples/openai_example.py
@@ -1,3 +1,5 @@
+# OpenAI API example:
+
 from memoripy import MemoryManager, JSONStorage
 from memoripy.implemented_models import OpenAIChatModel, OllamaEmbeddingModel
 

--- a/examples/openrouter.py
+++ b/examples/openrouter.py
@@ -1,0 +1,50 @@
+# OpenRouter example:
+
+from memoripy import MemoryManager, JSONStorage
+from memoripy.implemented_models import OpenRouterChatModel, OllamaEmbeddingModel
+
+def main():
+    # Replace 'your-api-key' with your actual API key for the chat completions service you use
+    api_key = "your-api-key"
+    if not api_key or api_key == "your-api-key":
+        raise ValueError("Please set your API key.")
+
+    # Define chat and embedding models
+    chat_model_name = "nousresearch/hermes-3-llama-3.1-405b:free" # Specific chat model name
+    embedding_model_name = "mxbai-embed-large"  # Specific embedding model name
+
+    # Choose your storage option
+    storage_option = JSONStorage("interaction_history.json")
+    # Or use in-memory storage:
+    # from memoripy import InMemoryStorage
+    # storage_option = InMemoryStorage()
+
+    # Initialize the MemoryManager with the selected models and storage
+    memory_manager = MemoryManager(OpenRouterChatModel(api_key, chat_model_name), OllamaEmbeddingModel(embedding_model_name), storage=storage_option)
+
+    # New user prompt
+    new_prompt = "My name is Khazar"
+
+    # Load the last 5 interactions from history (for context)
+    short_term, _ = memory_manager.load_history()
+    last_interactions = short_term[-5:] if len(short_term) >= 5 else short_term
+
+    # Retrieve relevant past interactions, excluding the last 5
+    relevant_interactions = memory_manager.retrieve_relevant_interactions(new_prompt, exclude_last_n=5)
+
+    # Generate a response using the last interactions and retrieved interactions
+    response = memory_manager.generate_response(new_prompt, last_interactions, relevant_interactions)
+
+    # Display the response
+    print(f"Generated response:\n{response}")
+
+    # Extract concepts for the new interaction
+    combined_text = f"{new_prompt} {response}"
+    concepts = memory_manager.extract_concepts(combined_text)
+
+    # Store this new interaction along with its embedding and concepts
+    new_embedding = memory_manager.get_embedding(combined_text)
+    memory_manager.add_interaction(new_prompt, response, new_embedding, concepts)
+
+if __name__ == "__main__":
+    main()

--- a/memoripy/implemented_models.py
+++ b/memoripy/implemented_models.py
@@ -107,3 +107,35 @@ class OllamaChatModel(ChatModel):
         concepts = response.get("concepts", [])
         print(f"Concepts extracted: {concepts}")
         return concepts
+
+class ChatCompletionsModel(ChatModel):
+    def __init__(self, api_endpoint: str, api_key: str, model_name: str):
+        self.api_key = api_key
+        self.model_name = model_name
+        self.llm = ChatOpenAI(openai_api_base = api_endpoint, openai_api_key = api_key, model_name = model_name)
+        self.parser = JsonOutputParser(pydantic_object=ConceptExtractionResponse)
+        self.prompt_template = PromptTemplate(
+            template=(
+                "Extract key concepts from the following text in a concise, context-specific manner. "
+                "Include only the most highly relevant and specific core concepts that best capture the text's meaning. "
+                "Return nothing but the JSON string.\n"
+                "{format_instructions}\n{text}"
+            ),
+            input_variables=["text"],
+            partial_variables={"format_instructions": self.parser.get_format_instructions()},
+        )
+
+    def invoke(self, messages: list) -> str:
+        response = self.llm.invoke(messages)
+        return str(response.content)
+    
+    def extract_concepts(self, text: str) -> list[str]:
+        chain = self.prompt_template | self.llm | self.parser
+        response = chain.invoke({"text": text})
+        concepts = response.get("concepts", [])
+        print(f"Concepts extracted: {concepts}")
+        return concepts
+
+class OpenRouterChatModel(ChatCompletionsModel):
+    def __init__(self, api_key: str, model_name: str):
+        super().__init__(api_endpoint="https://openrouter.ai/api/v1", api_key=api_key, model_name=model_name)


### PR DESCRIPTION
Toward #3 

This PR adds the `ChatCompletionsModel` class in the `implemented_models` package, allowing one to use any OpenAI-compatible chat completions API by providing an API endpoint, an API key, and a model name. It also adds the `OpenRouterChatModel` class, which is just a thin wrapper around `ChatCompletionsModel` with the endpoint set to `https://openrouter.ai/api/v1`.

The PR also adds a few examples to demonstrate usage of `ChatCompletionsModel` and `OpenRouterChatModel`.

`ChatCompletionsModel` was tested with OpenAI (`api_endpoint="https://api.openai.com/v1"`), OpenRouter (`api_endpoint="https://openrouter.ai/api/v1"` as well as the `OpenRouterChatModel` wrapper), and Infermatic (`api_endpoint=https://api.totalgpt.ai`).