### PR TITLE
Modification on Memory_manager.py

### DIFF
--- a/memoripy/memory_manager.py
+++ b/memoripy/memory_manager.py
@@ -63,7 +63,7 @@ class MemoryManager:
             "embedding": embedding.tolist(),
             "timestamp": timestamp,
             "access_count": 1,
-            "concepts": list(concepts),
+            "concepts": [str(concept) for concept in concepts], # Prevent the "unhashable type: 'dict'" error
             "decay_factor": 1.0,
         }
         self.memory_store.add_interaction(interaction)


### PR DESCRIPTION
Updated "add_interaction" to ensure concepts are properly converted to strings before being stored. This prevents the "unhashable type: 'dict'" error when adding interactions with extracted concepts.